### PR TITLE
add CORS headers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,5 +90,11 @@ services:
       - traefik.http.routers.xmpp-filer.tls=true
       - traefik.http.routers.xmpp-filer.tls.certresolver=letsencrypt
       - traefik.http.services.xmpp-filer.loadbalancer.server.port=5050
+      - traefik.http.middlewares.xmpp-filer.headers.accesscontrolallowmethods=GET,OPTIONS,PUT
+      - traefik.http.middlewares.xmpp-filer.headers.accesscontrolalloworiginlist=*
+      - traefik.http.middlewares.xmpp-filer.headers.accessControlAllowHeaders=Authorization,Content-Type
+      - traefik.http.middlewares.xmpp-filer.headers.accessControlAllowCredentials=true
+      - traefik.http.routers.xmpp-filer.middlewares=foo-add-prefix@docker
+
     networks:
       - web


### PR DESCRIPTION
Work in progress.

In order to fulfill [this compliance test](https://compliance.conversations.im/test/xep0363_cors/) the CORS headers for the http_external_upload must be set well.

Instructions given:

> If you are using mod_http_upload just make sure you are using the latest version. If you are using http_upload_external you should make sure that the script adds appropriate CORS headers.